### PR TITLE
Update action to run on node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ outputs:
   done:
     description: "returns true if successful"
 runs:
-  using: "node12"
+  using: "node16"
   main: "index.js"


### PR DESCRIPTION
According to Github actions latest guidelines all actions should get updated to node16
https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions